### PR TITLE
fix: File->getSize() return type

### DIFF
--- a/src/Http/File.php
+++ b/src/Http/File.php
@@ -64,7 +64,7 @@ class File extends UploadedFile
         return parent::getClientMediaType();
     }
 
-    public function getSize(): ?int
+    public function getSize(): int
     {
         if ($this->fakeSize !== null) {
             return $this->fakeSize;


### PR DESCRIPTION

```
PHP Fatal error:  Declaration of Spiral\Testing\Http\File::getSize(): ?int must be compatible with Nyholm\Psr7\UploadedFile::getSize(): int in vendor/spiral/testing/src/Http/File.php on line 67
```

https://github.com/Nyholm/psr7/blob/master/src/UploadedFile.php#L160  
