### PR TITLE
TestCase::getApp returns TestableKernelInterface

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -92,7 +92,7 @@ abstract class TestCase extends BaseTestCase
         $this->beforeInit[] = $callback;
     }
 
-    final public function getApp(): TestApp
+    final public function getApp(): TestableKernelInterface
     {
         return $this->app;
     }


### PR DESCRIPTION
This fixes allow me to extend TestCase and not copy-paste it for only one change.