### PR TITLE
Removing ROUTE_CACHE

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,7 +26,6 @@
     </filter>
 
     <php>
-        <env name="ROUTE_CACHE" value="false" />
         <env name="DEBUG" value="true" />
     </php>
 </phpunit>


### PR DESCRIPTION
Variable **ROUTE_CACHE** was removed:
https://github.com/spiral/framework/commit/a4d6639a5d7c9863d8b1ae80b0d3c7f0272e2859