### PR TITLE
PHP Attributes for Environment and Configuration Variables, and Exception Handling

### DIFF
--- a/src/Attribute/Config.php
+++ b/src/Attribute/Config.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Attribute;
+
+use Attribute;
+use Closure;
+
+#[Attribute(flags: Attribute::TARGET_METHOD|Attribute::IS_REPEATABLE)]
+final class Config
+{
+    public ?Closure $closure;
+
+    public function __construct(
+        public string $path,
+        public mixed $value = null,
+        callable $closure = null,
+    ) {
+        $this->closure = $closure !== null ? $closure(...) : null;
+    }
+}

--- a/src/Attribute/Env.php
+++ b/src/Attribute/Env.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Attribute;
+
+use Attribute;
+
+#[Attribute(flags: Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final class Env
+{
+    public function __construct(
+        public readonly string $key,
+        public readonly int|string|null|bool $value = null,
+    ) {
+    }
+}

--- a/src/Attribute/WithoutExceptionHandling.php
+++ b/src/Attribute/WithoutExceptionHandling.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Attribute;
+
+use Attribute;
+
+#[Attribute(flags: Attribute::TARGET_METHOD)]
+final class WithoutExceptionHandling
+{
+}

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -183,8 +183,9 @@ abstract class TestCase extends BaseTestCase
     protected function getTestAttributes(string $attribute, string $method = null): array
     {
         try {
+            $methodName = $method ?? (\method_exists($this, 'name') ? $this->name() : $this->getName(false));
             $result = [];
-            $attributes = (new \ReflectionMethod($this, $method ?? $this->name()))->getAttributes($attribute);
+            $attributes = (new \ReflectionMethod($this, $methodName))->getAttributes($attribute);
             foreach ($attributes as $attr) {
                 $result[] = $attr->newInstance();
             }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -64,9 +64,9 @@ abstract class TestCase extends BaseTestCase
     {
         return [
             'root' => $root,
-            'app' => $root.'/app',
-            'runtime' => $root.'/runtime',
-            'cache' => $root.'/runtime/cache',
+            'app' => $root . '/app',
+            'runtime' => $root . '/runtime',
+            'cache' => $root . '/runtime/cache',
         ];
     }
 
@@ -80,7 +80,8 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
 
         if (static::MAKE_APP_ON_STARTUP) {
-            $this->initApp(static::ENV);
+            $variables = [...static::ENV, ...$this->getEnvVariablesFromConfig()];
+            $this->initApp($variables);
         }
     }
 
@@ -142,6 +143,9 @@ abstract class TestCase extends BaseTestCase
     public function initApp(array $env = []): void
     {
         $this->app = $this->makeApp($env);
+        $this->suppressExceptionHandlingIfAttributeDefined();
+        $this->updateConfigFromAttribute();
+
         (new \ReflectionClass(ContainerScope::class))
             ->setStaticPropertyValue('container', $this->app->getContainer());
     }
@@ -165,5 +169,28 @@ abstract class TestCase extends BaseTestCase
 
         (new \ReflectionClass(ContainerScope::class))
             ->setStaticPropertyValue('container', null);
+    }
+
+
+    /**
+     * @template TClass
+     *
+     * @param class-string<TClass> $attribute
+     * @param null|non-empty-string $method Method name
+     *
+     * @return array<int, TClass>
+     */
+    protected function getTestAttributes(string $attribute, string $method = null): array
+    {
+        try {
+            $result = [];
+            $attributes = (new \ReflectionMethod($this, $method ?? $this->name()))->getAttributes($attribute);
+            foreach ($attributes as $attr) {
+                $result[] = $attr->newInstance();
+            }
+            return $result;
+        } catch (\Throwable) {
+            return [];
+        }
     }
 }

--- a/src/Traits/InteractsWithConfig.php
+++ b/src/Traits/InteractsWithConfig.php
@@ -7,6 +7,7 @@ namespace Spiral\Testing\Traits;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Config\Patch\Set;
 use Spiral\Core\ConfigsInterface;
+use Spiral\Testing\Attribute;
 
 trait InteractsWithConfig
 {
@@ -51,5 +52,13 @@ trait InteractsWithConfig
         [$config, $key] = explode('.', $key, 2);
 
         $this->getConfigs()->modify($config, new Set($key, $data));
+    }
+
+    private function updateConfigFromAttribute(): void
+    {
+        foreach ($this->getTestAttributes(Attribute\Config::class) as $attribute) {
+            \assert($attribute instanceof Attribute\Config);
+            $this->updateConfig($attribute->path, $attribute->closure?->__invoke() ?? $attribute->value);
+        }
     }
 }

--- a/src/Traits/InteractsWithCore.php
+++ b/src/Traits/InteractsWithCore.php
@@ -7,6 +7,7 @@ namespace Spiral\Testing\Traits;
 use Spiral\Boot\Bootloader\BootloaderInterface;
 use Spiral\Boot\Environment;
 use Spiral\Boot\EnvironmentInterface;
+use Spiral\Testing\Attribute;
 
 trait InteractsWithCore
 {
@@ -174,5 +175,21 @@ trait InteractsWithCore
             $this->getContainer()->get(EnvironmentInterface::class)->getAll(),
             \sprintf('Environment does not have key with name [%s].', $key)
         );
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private function getEnvVariablesFromConfig(): array
+    {
+        $variables = [];
+
+        foreach ($this->getTestAttributes(Attribute\Env::class) as $attribute) {
+            \assert($attribute instanceof Attribute\Env);
+
+            $variables[$attribute->key] = $attribute->value;
+        }
+
+        return $variables;
     }
 }

--- a/src/Traits/InteractsWithExceptions.php
+++ b/src/Traits/InteractsWithExceptions.php
@@ -7,6 +7,7 @@ namespace Spiral\Testing\Traits;
 use Spiral\Exceptions\ExceptionHandlerInterface;
 use Spiral\Exceptions\ExceptionRendererInterface;
 use Spiral\Exceptions\Verbosity;
+use Spiral\Testing\Attribute\WithoutExceptionHandling;
 
 trait InteractsWithExceptions
 {
@@ -47,5 +48,12 @@ trait InteractsWithExceptions
                 }
             }
         );
+    }
+
+    private function suppressExceptionHandlingIfAttributeDefined(): void
+    {
+        if (\count($this->getTestAttributes(WithoutExceptionHandling::class)) > 0) {
+            $this->withoutExceptionHandling();
+        }
     }
 }

--- a/tests/src/Attribute/ConfigTest.php
+++ b/tests/src/Attribute/ConfigTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\Attribute;
+
+use Spiral\Storage\Config\StorageConfig;
+use Spiral\Testing\Attribute\Config;
+use Spiral\Testing\Tests\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    public function testDefaultSettings(): void
+    {
+        $config = $this->getConfig(StorageConfig::CONFIG);
+        $this->assertSame('uploads', $config['default']);
+    }
+
+    #[Config('storage.default', 'replaced')]
+    public function testReplaceUsingAttribute(): void
+    {
+        $config = $this->getConfig(StorageConfig::CONFIG);
+        $this->assertSame('replaced', $config['default']);
+    }
+
+    #[Config('storage.default', 'replaced')]
+    #[Config('storage.servers.static.adapter', 'test')]
+    public function testMultipleAttributes(): void
+    {
+        $config = $this->getConfig(StorageConfig::CONFIG);
+        $this->assertSame('replaced', $config['default']);
+        $this->assertSame('test', $config['servers']['static']['adapter']);
+    }
+}

--- a/tests/src/Attribute/EnvTest.php
+++ b/tests/src/Attribute/EnvTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\Attribute;
+
+use Spiral\Testing\Attribute\Env;
+use Spiral\Testing\Tests\TestCase;
+
+final class EnvTest extends TestCase
+{
+    public const ENV = [
+        'FOO' => 'BAR',
+        'BAZ' => 'QUX'
+    ];
+
+    public function testDefaultEnv(): void
+    {
+        $this->assertEnvironmentValueSame('FOO', 'BAR');
+        $this->assertEnvironmentValueSame('BAZ', 'QUX');
+    }
+
+    #[Env('FOO', 'BAZ')]
+    public function testEnvFromAttribute(): void
+    {
+        $this->assertEnvironmentValueSame('FOO', 'BAZ');
+        $this->assertEnvironmentValueSame('BAZ', 'QUX');
+    }
+
+    #[Env('FOO', 'BAZ')]
+    #[Env('BAZ', 'BAZ')]
+    public function testMultipleAttributes(): void
+    {
+        $this->assertEnvironmentValueSame('FOO', 'BAZ');
+        $this->assertEnvironmentValueSame('BAZ', 'BAZ');
+    }
+}

--- a/tests/src/Attribute/WithoutExceptionHandlingTest.php
+++ b/tests/src/Attribute/WithoutExceptionHandlingTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\Attribute;
+
+use Spiral\Exceptions\ExceptionHandler;
+use Spiral\Exceptions\ExceptionHandlerInterface;
+use Spiral\Testing\Attribute\WithoutExceptionHandling;
+use Spiral\Testing\Tests\TestCase;
+
+final class WithoutExceptionHandlingTest extends TestCase
+{
+    public function testDefaultHandler(): void
+    {
+        $this->assertInstanceOf(
+            ExceptionHandler::class,
+            $this->getContainer()->get(ExceptionHandlerInterface::class)
+        );
+    }
+
+    public function testSuppressWithMethod(): void
+    {
+        $this->withoutExceptionHandling();
+
+        $this->assertNotInstanceOf(
+            ExceptionHandler::class,
+            $this->getContainer()->get(ExceptionHandlerInterface::class)
+        );
+    }
+
+    #[WithoutExceptionHandling]
+    public function testSuppressWithAttribute(): void
+    {
+        $this->assertNotInstanceOf(
+            ExceptionHandler::class,
+            $this->getContainer()->get(ExceptionHandlerInterface::class)
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces several new features to the testing package, enhancing its capabilities for unit testing. The following features have been added:

### 1. Redefining Environment (ENV) Variables

You can now redefine specific ENV variables for unit tests using PHP attributes. This allows for more granular control over the test environment.

```php
use Spiral\Testing\Attribute\Env;

#[Env('FOO', 'BAZ')]
#[Env('BAZ', 'BAZ')]
public function testMultipleAttributes(): void
{
    // Test logic here
}
```

### 2. Configuring spiral config variables

Configuration variables can now be modified using attributes in unit tests.

```php
use Spiral\Testing\Attribute\Config;

#[Config('storage.default', 'replaced')]
#[Config('storage.servers.static.adapter', 'test')]
public function testMultipleAttributes(): void
{
    // Test logic here
}
```

### 3. Disabling Exception Handler 

```php
#[WithoutExceptionHandling]
public function testSuppressWithAttribute(): void
{
    // Test logic here
}
```