### PR TITLE
InteractsWithMailer, InteractsWithQueue. Ability to use several times

### DIFF
--- a/src/Mailer/FakeMailer.php
+++ b/src/Mailer/FakeMailer.php
@@ -89,4 +89,9 @@ class FakeMailer implements MailerInterface
             $this->messages[] = $msg;
         }
     }
+
+    public function clear(): void
+    {
+        $this->messages = [];
+    }
 }

--- a/src/Queue/FakeQueue.php
+++ b/src/Queue/FakeQueue.php
@@ -114,4 +114,9 @@ class FakeQueue implements QueueInterface
 
         return 'job-id';
     }
+
+    public function clear(): void
+    {
+        $this->jobs = [];
+    }
 }

--- a/src/Queue/FakeQueueManager.php
+++ b/src/Queue/FakeQueueManager.php
@@ -40,4 +40,11 @@ class FakeQueueManager implements QueueConnectionProviderInterface
     {
         return $this->config->getDefaultDriver();
     }
+
+    public function clearAll(): void
+    {
+        foreach ($this->connections as $connection) {
+            $connection->clear();
+        }
+    }
 }

--- a/src/Traits/InteractsWithMailer.php
+++ b/src/Traits/InteractsWithMailer.php
@@ -11,7 +11,15 @@ trait InteractsWithMailer
 {
     public function fakeMailer(): FakeMailer
     {
-        $this->getContainer()->bindSingleton(
+        $container = $this->getContainer();
+        if ($container->has(MailerInterface::class)) {
+            $mailer = $container->get(MailerInterface::class);
+            if ($mailer instanceof FakeMailer) {
+                return $mailer;
+            }
+        }
+
+        $container->bindSingleton(
             MailerInterface::class,
             $mailer = new FakeMailer()
         );

--- a/src/Traits/InteractsWithQueue.php
+++ b/src/Traits/InteractsWithQueue.php
@@ -11,9 +11,17 @@ trait InteractsWithQueue
 {
     public function fakeQueue(): FakeQueueManager
     {
-        $this->getContainer()->bindSingleton(
+        $container = $this->getContainer();
+        if ($container->has(QueueConnectionProviderInterface::class)) {
+            $manager = $container->get(QueueConnectionProviderInterface::class);
+            if ($manager instanceof FakeQueueManager) {
+                return $manager;
+            }
+        }
+
+        $container->bindSingleton(
             QueueConnectionProviderInterface::class,
-            $manager = $this->getContainer()->get(FakeQueueManager::class)
+            $manager = $container->get(FakeQueueManager::class)
         );
 
         return $manager;

--- a/tests/src/Traits/InteractsWithMailerTest.php
+++ b/tests/src/Traits/InteractsWithMailerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\Traits;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Core\Container;
+use Spiral\Mailer\MailerInterface;
+use Spiral\Testing\Mailer\FakeMailer;
+use Spiral\Testing\Traits\InteractsWithMailer;
+
+/**
+ * @coversDefaultClass InteractsWithMailer
+ */
+final class InteractsWithMailerTest extends TestCase
+{
+    public function test(): void
+    {
+        $container = new Container();
+        self::assertFalse($container->has(MailerInterface::class));
+
+        $object = $this->getSomeService($container);
+        $mailer = $object->fakeMailer();
+        self::assertInstanceOf(FakeMailer::class, $mailer);
+        self::assertTrue($container->has(MailerInterface::class));
+        $mailer2 = $object->fakeMailer();
+        self::assertSame($mailer, $mailer2);
+    }
+
+    private function getSomeService(Container $container):object
+    {
+        return new class ($container) {
+            use InteractsWithMailer;
+
+            public function __construct(
+                private readonly Container $container
+            )  {
+            }
+
+            public function getContainer(): Container
+            {
+                return $this->container;
+            }
+        };
+    }
+}

--- a/tests/src/Traits/InteractsWithQueueTest.php
+++ b/tests/src/Traits/InteractsWithQueueTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\Traits;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Core\Container;
+use Spiral\Queue\Config\QueueConfig;
+use Spiral\Queue\QueueConnectionProviderInterface;
+use Spiral\Testing\Queue\FakeQueueManager;
+use Spiral\Testing\Traits\InteractsWithQueue;
+
+/**
+ * @coversDefaultClass InteractsWithQueue
+ */
+final class InteractsWithQueueTest extends TestCase
+{
+    public function test(): void
+    {
+        $container = new Container();
+        $manager = new FakeQueueManager($container, new QueueConfig());
+        $container->bind(FakeQueueManager::class, $manager);
+        self::assertFalse($container->has(QueueConnectionProviderInterface::class));
+
+        $object = $this->getSomeService($container);
+        $queue = $object->fakeQueue();
+        self::assertInstanceOf(FakeQueueManager::class, $queue);
+        self::assertTrue($container->has(QueueConnectionProviderInterface::class));
+        $queue2 = $object->fakeQueue();
+        self::assertSame($queue, $queue2);
+    }
+
+    private function getSomeService(Container $container):object
+    {
+        return new class ($container) {
+            use InteractsWithQueue;
+
+            public function __construct(
+                private readonly Container $container
+            )  {
+            }
+
+            public function getContainer(): Container
+            {
+                return $this->container;
+            }
+        };
+    }
+}


### PR DESCRIPTION
I use one app for several testCases.
For every `fakeMailer` call it creates new instance, and replace it in container, but some services already have reference to first instance of FakeMailer.

This fix allow to access to single `fakeMaker`