### PR TITLE
FakeHttp add method `getJsonParsedBody`

### DIFF
--- a/src/Http/TestResponse.php
+++ b/src/Http/TestResponse.php
@@ -219,4 +219,12 @@ final class TestResponse implements \Stringable
     {
         return $this->cookies;
     }
+
+    public function getJsonParsedBody(): array
+    {
+        return \json_decode(
+            (string)$this->response->getBody(),
+            true
+        );
+    }
 }

--- a/tests/src/Http/FakeHttpTest.php
+++ b/tests/src/Http/FakeHttpTest.php
@@ -45,4 +45,18 @@ final class FakeHttpTest extends TestCase
         $response = $http->get('/get/headers');
         $response->assertBodySame('{"baz":["bar"],"foo":["bar"]}');
     }
+
+    public function testGetJsonParsedBody(): void
+    {
+        $http = $this->fakeHttp();
+        $arr = [
+            'foo' => 'bar',
+            'list' => [1, 2, 3, 4]
+        ];
+        $response = $http->get('/get/query-params', $arr);
+        self::assertSame(
+            $arr,
+            $response->getJsonParsedBody()
+        );
+    }
 }


### PR DESCRIPTION
Now we can do like this

```php
$response = $http->get('/get/query-params', $arr);
self::assertSame(
    $arr,
    $response->getJsonParsedBody()
);
```