### PR TITLE
Adding the ability to use setUp and tearDown methods in traits

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -202,23 +202,32 @@ abstract class TestCase extends BaseTestCase
 
     protected function setUpTraits(): void
     {
-        $ref = new \ReflectionClass(static::class);
-
-        foreach ($ref->getTraits() as $trait) {
-            if (\method_exists($this, $method = 'setUp' . $trait->getShortName())) {
-                $this->{$method}();
-            }
-        }
+        $this->runTraitSetUpOrTearDown('setUp');
     }
 
     protected function tearDownTraits(): void
     {
+        $this->runTraitSetUpOrTearDown('tearDown');
+    }
+
+    private function runTraitSetUpOrTearDown(string $method): void
+    {
         $ref = new \ReflectionClass(static::class);
 
         foreach ($ref->getTraits() as $trait) {
-            if (\method_exists($this, $method = 'tearDown' . $trait->getShortName())) {
-                $this->{$method}();
+            if (\method_exists($this, $name = $method . $trait->getShortName())) {
+                $this->{$name}();
             }
+        }
+
+        while($parent = $ref->getParentClass()) {
+            foreach ($parent->getTraits() as $trait) {
+                if (\method_exists($this, $name = $method . $trait->getShortName())) {
+                    $this->{$name}();
+                }
+            }
+
+            $ref = $parent;
         }
     }
 }

--- a/tests/src/TestCase/Fixture/OtherParentClass.php
+++ b/tests/src/TestCase/Fixture/OtherParentClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture;
+
+class OtherParentClass extends ParentClass
+{
+}

--- a/tests/src/TestCase/Fixture/ParentClass.php
+++ b/tests/src/TestCase/Fixture/ParentClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture;
+
+use Spiral\Testing\TestCase;
+use Spiral\Testing\Tests\TestCase\Fixture\Trait\WithMethodsTrait;
+
+class ParentClass extends TestCase
+{
+    use WithMethodsTrait;
+}

--- a/tests/src/TestCase/Fixture/Trait/WithMethodsTrait.php
+++ b/tests/src/TestCase/Fixture/Trait/WithMethodsTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture\Trait;
+
+trait WithMethodsTrait
+{
+    public bool $calledSetUp = false;
+    public bool $calledTearDown = false;
+
+    public function setUpWithMethodsTrait(): void
+    {
+        $this->calledSetUp = true;
+    }
+
+    public function tearDownWithMethodsTrait(): void
+    {
+        $this->calledTearDown = true;
+    }
+}

--- a/tests/src/TestCase/Fixture/Trait/WithSetUpTrait.php
+++ b/tests/src/TestCase/Fixture/Trait/WithSetUpTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture\Trait;
+
+trait WithSetUpTrait
+{
+    public bool $calledSetUp = false;
+
+    public function setUpWithSetUpTrait(): void
+    {
+        $this->calledSetUp = true;
+    }
+}

--- a/tests/src/TestCase/Fixture/Trait/WithTearDownTrait.php
+++ b/tests/src/TestCase/Fixture/Trait/WithTearDownTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture\Trait;
+
+trait WithTearDownTrait
+{
+    public bool $calledTearDown = false;
+
+    public function tearDownWithTearDownTrait(): void
+    {
+        $this->calledTearDown = true;
+    }
+}

--- a/tests/src/TestCase/Fixture/Trait/WithoutMethodsTrait.php
+++ b/tests/src/TestCase/Fixture/Trait/WithoutMethodsTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture\Trait;
+
+trait WithoutMethodsTrait
+{
+    public function isAvailable(): bool
+    {
+        return true;
+    }
+}

--- a/tests/src/TestCase/Fixture/WithMethods.php
+++ b/tests/src/TestCase/Fixture/WithMethods.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture;
+
+use Spiral\Testing\TestCase;
+use Spiral\Testing\Tests\TestCase\Fixture\Trait\WithMethodsTrait;
+
+final class WithMethods extends TestCase
+{
+    use WithMethodsTrait;
+}

--- a/tests/src/TestCase/Fixture/WithMethodsInNestedParent.php
+++ b/tests/src/TestCase/Fixture/WithMethodsInNestedParent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture;
+
+final class WithMethodsInNestedParent extends OtherParentClass
+{
+}

--- a/tests/src/TestCase/Fixture/WithMethodsInParent.php
+++ b/tests/src/TestCase/Fixture/WithMethodsInParent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture;
+
+final class WithMethodsInParent extends ParentClass
+{
+}

--- a/tests/src/TestCase/Fixture/WithSetUp.php
+++ b/tests/src/TestCase/Fixture/WithSetUp.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture;
+
+use Spiral\Testing\TestCase;
+use Spiral\Testing\Tests\TestCase\Fixture\Trait\WithSetUpTrait;
+
+final class WithSetUp extends TestCase
+{
+    use WithSetUpTrait;
+}

--- a/tests/src/TestCase/Fixture/WithTearDown.php
+++ b/tests/src/TestCase/Fixture/WithTearDown.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture;
+
+use Spiral\Testing\TestCase;
+use Spiral\Testing\Tests\TestCase\Fixture\Trait\WithTearDownTrait;
+
+final class WithTearDown extends TestCase
+{
+    use WithTearDownTrait;
+}

--- a/tests/src/TestCase/Fixture/WithoutMethods.php
+++ b/tests/src/TestCase/Fixture/WithoutMethods.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture;
+
+use Spiral\Testing\TestCase;
+use Spiral\Testing\Tests\TestCase\Fixture\Trait\WithoutMethodsTrait;
+
+final class WithoutMethods extends TestCase
+{
+    use WithoutMethodsTrait;
+}

--- a/tests/src/TestCase/Fixture/WithoutTraits.php
+++ b/tests/src/TestCase/Fixture/WithoutTraits.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase\Fixture;
+
+use Spiral\Testing\TestCase;
+
+final class WithoutTraits extends TestCase
+{
+}

--- a/tests/src/TestCase/TestCaseTest.php
+++ b/tests/src/TestCase/TestCaseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\TestCase;
+
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\TestCase;
+use Spiral\Testing\Tests\TestCase\Fixture\WithMethods;
+use Spiral\Testing\Tests\TestCase\Fixture\WithoutMethods;
+use Spiral\Testing\Tests\TestCase\Fixture\WithoutTraits;
+use Spiral\Testing\Tests\TestCase\Fixture\WithSetUp;
+use Spiral\Testing\Tests\TestCase\Fixture\WithTearDown;
+
+final class TestCaseTest extends TestCase
+{
+    #[DoesNotPerformAssertions]
+    public function testItDoesNotThrowWhenCallingSetUp(): void
+    {
+        $testCase = new WithoutTraits('foo');
+        $testCase->setUp();
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testItDoesNotThrowWhenCallingTearDown(): void
+    {
+        $testCase = new WithoutTraits('foo');
+        $testCase->tearDown();
+    }
+
+    public function testTraitWithoutMethods(): void
+    {
+        $testCase = new WithoutMethods('foo');
+        $testCase->setUp();
+        $testCase->tearDown();
+
+        $this->assertTrue($testCase->isAvailable());
+    }
+
+    public function testTraitWithSetUp(): void
+    {
+        $testCase = new WithSetUp('foo');
+        $testCase->setUp();
+        $testCase->tearDown();
+
+        $this->assertTrue($testCase->calledSetUp);
+    }
+
+    public function testTraitWithTearDown(): void
+    {
+        $testCase = new WithTearDown('foo');
+        $testCase->setUp();
+        $testCase->tearDown();
+
+        $this->assertTrue($testCase->calledTearDown);
+    }
+
+    public function testTraitWithSetUpAndTearDownMethods(): void
+    {
+        $testCase = new WithMethods('foo');
+        $testCase->setUp();
+        $testCase->tearDown();
+
+        $this->assertTrue($testCase->calledSetUp);
+        $this->assertTrue($testCase->calledTearDown);
+    }
+}

--- a/tests/src/TestCase/TestCaseTest.php
+++ b/tests/src/TestCase/TestCaseTest.php
@@ -7,6 +7,8 @@ namespace Spiral\Testing\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use Spiral\Testing\Tests\TestCase\Fixture\WithMethods;
+use Spiral\Testing\Tests\TestCase\Fixture\WithMethodsInNestedParent;
+use Spiral\Testing\Tests\TestCase\Fixture\WithMethodsInParent;
 use Spiral\Testing\Tests\TestCase\Fixture\WithoutMethods;
 use Spiral\Testing\Tests\TestCase\Fixture\WithoutTraits;
 use Spiral\Testing\Tests\TestCase\Fixture\WithSetUp;
@@ -14,6 +16,9 @@ use Spiral\Testing\Tests\TestCase\Fixture\WithTearDown;
 
 final class TestCaseTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     #[DoesNotPerformAssertions]
     public function testItDoesNotThrowWhenCallingSetUp(): void
     {
@@ -21,6 +26,9 @@ final class TestCaseTest extends TestCase
         $testCase->setUp();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     #[DoesNotPerformAssertions]
     public function testItDoesNotThrowWhenCallingTearDown(): void
     {
@@ -58,6 +66,26 @@ final class TestCaseTest extends TestCase
     public function testTraitWithSetUpAndTearDownMethods(): void
     {
         $testCase = new WithMethods('foo');
+        $testCase->setUp();
+        $testCase->tearDown();
+
+        $this->assertTrue($testCase->calledSetUp);
+        $this->assertTrue($testCase->calledTearDown);
+    }
+
+    public function testTraitWithSetUpAndTearDownMethodsInParentClass(): void
+    {
+        $testCase = new WithMethodsInParent('foo');
+        $testCase->setUp();
+        $testCase->tearDown();
+
+        $this->assertTrue($testCase->calledSetUp);
+        $this->assertTrue($testCase->calledTearDown);
+    }
+
+    public function testTraitWithSetUpAndTearDownMethodsInNestedParentClass(): void
+    {
+        $testCase = new WithMethodsInNestedParent('foo');
         $testCase->setUp();
         $testCase->tearDown();
 


### PR DESCRIPTION
### Feature

This pull request introduces a new feature to enhance testing capabilities. It enables the usage of `setUpTraitName` and `tearDownTraitName` methods in traits, which will be automatically invoked within the `setUp` and `tearDown` methods before and after test execution, respectively. Instead of `TraitName`, the specific trait name should be provided.

#### Example

**Trait**
```php
trait ShowQueries
{
    protected function setUpShowQueries(): void
    {
        $this->configureLogger();
    }

    protected function tearDownShowQueries(): void
    {
        $this->restoreLogger();
    }

    private function configureLogger(): void
    {
        // ...
    }

    private function restoreLogger(): void
    {
        // ... 
    }
}
```

**TestCase**
```php
use Spiral\Testing\TestCase;

final class SomeTest extends TestCase
{
    use ShowQueries;
}
```
