### PR TITLE
Fixing config modifications using an attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
     "ext-gd": "Required to use generate fake image files"
   },
   "require-dev": {
+    "spiral/framework": "^3.11",
     "spiral/roadrunner-bridge": "^2.2 || ^3.0",
     "spiral-packages/league-event": "^1.0.1",
     "spiral/nyholm-bridge": "^1.2",

--- a/src/Traits/InteractsWithConfig.php
+++ b/src/Traits/InteractsWithConfig.php
@@ -54,6 +54,9 @@ trait InteractsWithConfig
         $this->getConfigs()->modify($config, new Set($key, $data));
     }
 
+    /**
+     * @deprecated since v2.6.4
+     */
     private function updateConfigFromAttribute(): void
     {
         foreach ($this->getTestAttributes(Attribute\Config::class) as $attribute) {

--- a/tests/app/Bootloader/BlogBootloader.php
+++ b/tests/app/Bootloader/BlogBootloader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Testing\Tests\App\Bootloader;
 
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Storage\Config\StorageConfig;
 use Spiral\Testing\Tests\App\Repositories\ArrayPostRepository;
 use Spiral\Testing\Tests\App\Repositories\PostRepositoryInterface;
 use Spiral\Testing\Tests\App\Services\BlogService;
@@ -19,6 +20,13 @@ final class BlogBootloader extends Bootloader
     protected const SINGLETONS = [
         PostRepositoryInterface::class => [self::class, 'initPostRepository']
     ];
+
+    /**
+     * The configuration file should be modified by an attribute BEFORE it's used in the boot method
+     */
+    public function boot(StorageConfig $config): void
+    {
+    }
 
     protected function initPostRepository(): PostRepositoryInterface
     {

--- a/tests/src/Attribute/ConfigTest.php
+++ b/tests/src/Attribute/ConfigTest.php
@@ -24,11 +24,11 @@ final class ConfigTest extends TestCase
     }
 
     #[Config('storage.default', 'replaced')]
-    #[Config('storage.servers.static.adapter', 'test')]
+    #[Config('storage.servers.static.directory', 'test')]
     public function testMultipleAttributes(): void
     {
         $config = $this->getConfig(StorageConfig::CONFIG);
         $this->assertSame('replaced', $config['default']);
-        $this->assertSame('test', $config['servers']['static']['adapter']);
+        $this->assertSame('test', $config['servers']['static']['directory']);
     }
 }

--- a/tests/src/Scaffolder/ScaffolderTest.php
+++ b/tests/src/Scaffolder/ScaffolderTest.php
@@ -72,7 +72,7 @@ PHP,
 
         $this->assertScaffolderCommandSame(
             'create:command',
-            [],
+            ['-n' => false],
             '',
         );
     }


### PR DESCRIPTION
Closes: #67 

1. If the configuration file is used in the bootloader's `boot` method, its modification in the test using the `Spiral\Testing\Attribute\Config` attribute causes an exception:

```
Spiral\Config\Exception\ConfigDeliveredException: Unable to patch config `...`, config object has already been delivered.
```

However, configuration files should be ready for use by this point. The config modification has been fixed, now it is done before the boot methods are executed.

2. The **spiral/framework** has been added to **require-dev**. It is necessary for tests in this package, but was not explicitly required, it was in **spiral/roadrunner-bridge** until version 3.2.0:
https://github.com/spiral/roadrunner-bridge/compare/3.1.0...3.2.0
Now it's not there and the tests are failing due to its absence. 