### PR TITLE
Add compatibility with Spiral Framework 3.12.0 dispatchers

### DIFF
--- a/src/Traits/InteractsWithDispatcher.php
+++ b/src/Traits/InteractsWithDispatcher.php
@@ -15,7 +15,7 @@ trait InteractsWithDispatcher
     public function assertDispatcherCanBeServed(string $dispatcher): void
     {
         $this->assertTrue(
-            $this->getContainer()->get($dispatcher)->canServe(),
+            $this->getContainer()->invoke([$dispatcher, 'canServe']),
             \sprintf('Dispatcher [%s] can not be served.', $dispatcher)
         );
     }
@@ -26,7 +26,7 @@ trait InteractsWithDispatcher
     public function assertDispatcherCannotBeServed(string $dispatcher): void
     {
         $this->assertFalse(
-            $this->getContainer()->get($dispatcher)->canServe(),
+            $this->getContainer()->invoke([$dispatcher, 'canServe']),
             \sprintf('Dispatcher [%s] can be served.', $dispatcher)
         );
     }
@@ -77,8 +77,6 @@ trait InteractsWithDispatcher
      */
     public function getRegisteredDispatchers(): array
     {
-        return array_map(static function ($dispatcher): string {
-            return get_class($dispatcher);
-        }, $this->getContainer()->get(KernelInterface::class)->getRegisteredDispatchers());
+        return $this->getContainer()->get(KernelInterface::class)->getRegisteredDispatchers();
     }
 }

--- a/src/Traits/InteractsWithDispatcher.php
+++ b/src/Traits/InteractsWithDispatcher.php
@@ -77,6 +77,8 @@ trait InteractsWithDispatcher
      */
     public function getRegisteredDispatchers(): array
     {
-        return $this->getContainer()->get(KernelInterface::class)->getRegisteredDispatchers();
+        return \array_map(static function ($dispatcher): string {
+            return \is_object($dispatcher) ? $dispatcher::class : $dispatcher;
+        }, $this->getContainer()->get(KernelInterface::class)->getRegisteredDispatchers());
     }
 }

--- a/src/Traits/TestableKernel.php
+++ b/src/Traits/TestableKernel.php
@@ -15,10 +15,14 @@ trait TestableKernel
         return $this->container;
     }
 
-    /** @return DispatcherInterface[] */
+    /** @return array<class-string<DispatcherInterface>> */
     public function getRegisteredDispatchers(): array
     {
-        return $this->dispatchers;
+        return \array_map(static fn (string|DispatcherInterface $dispatcher): string => \is_object($dispatcher)
+            ? $dispatcher::class
+            : $dispatcher,
+            $this->dispatchers
+        );
     }
 
     /** @return array<class-string> */

--- a/tests/src/Traits/InteractsWithDispatcherTest.php
+++ b/tests/src/Traits/InteractsWithDispatcherTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\Traits;
+
+use Spiral\Boot\DispatcherInterface;
+use Spiral\Boot\Environment;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Testing\TestCase;
+use Spiral\Testing\Traits\InteractsWithDispatcher;
+
+/**
+ * @coversDefaultClass InteractsWithDispatcher
+ */
+final class InteractsWithDispatcherTest extends TestCase
+{
+    public function testAssertDispatcherCanBeServed(): void
+    {
+        $dispatcher = new class implements DispatcherInterface {
+            public function canServe(): bool
+            {
+                return true;
+            }
+
+            public function serve(): void {}
+        };
+
+        $this->assertDispatcherCanBeServed($dispatcher::class);
+    }
+
+    public function testAssertDispatcherCanBeServedStaticMethodWithEnv(): void
+    {
+        $dispatcher = new class {
+            public function canServe(EnvironmentInterface $env): bool
+            {
+                return $env->get('MODE') === 'http';
+            }
+        };
+
+        $this->getContainer()->bindSingleton(EnvironmentInterface::class, new Environment(['MODE' => 'http']), true);
+        $this->assertDispatcherCanBeServed($dispatcher::class);
+    }
+
+    public function testAssertDispatcherCannotBeServed(): void
+    {
+        $dispatcher = new class implements DispatcherInterface {
+            public function canServe(): bool
+            {
+                return false;
+            }
+
+            public function serve(): void {}
+        };
+
+        $this->assertDispatcherCannotBeServed($dispatcher::class);
+    }
+
+    public function testAssertDispatcherCannotBeServedStaticMethodWithEnv(): void
+    {
+        $dispatcher = new class {
+            public function canServe(EnvironmentInterface $env): bool
+            {
+                return $env->get('MODE') === 'http';
+            }
+        };
+
+        $this->getContainer()->bindSingleton(EnvironmentInterface::class, new Environment(['MODE' => 'jobs']), true);
+        $this->assertDispatcherCannotBeServed($dispatcher::class);
+    }
+
+    public function testGetRegisteredDispatchers(): void
+    {
+        $dispatcherA = $this->createMock(DispatcherInterface::class);
+        $dispatcherB = $this->createMock(DispatcherInterface::class);
+
+        $ref = new \ReflectionProperty($this->getApp(), 'dispatchers');
+        $ref->setValue($this->getApp(), [$dispatcherA, $dispatcherB::class]);
+
+        $this->assertSame(
+            [$dispatcherA::class, $dispatcherB::class],
+            $this->getRegisteredDispatchers(),
+        );
+    }
+}


### PR DESCRIPTION
### What was changed

1. Since version 3.12, the `dispatchers` property in Kernel will contain an array of **class-strings**, not **objects**. For compatibility with both variants, the ability to work correctly with both strings and objects has been added.
2. Method `canServe` will be removed from the interface and a static method 'canServe' accepting 'Spiral\Boot\EnvironmentInterface' in parameters will be added to all dispatchers. The static method will be added to the interface in version 4.0. The package code should be able to work with both method variants.