### PR TITLE
Fake event dispatcher

### DIFF
--- a/src/Events/FakeEventDispatcher.php
+++ b/src/Events/FakeEventDispatcher.php
@@ -178,4 +178,9 @@ class FakeEventDispatcher implements EventDispatcherInterface
 
         return false;
     }
+
+    public function clear(): void
+    {
+        $this->dispatchedEvents = [];
+    }
 }

--- a/src/Events/FakeEventDispatcher.php
+++ b/src/Events/FakeEventDispatcher.php
@@ -163,6 +163,11 @@ class FakeEventDispatcher implements EventDispatcherInterface
         return isset($this->dispatchedEvents[$event]) && $this->dispatchedEvents[$event] !== [];
     }
 
+    public function clear(): void
+    {
+        $this->dispatchedEvents = [];
+    }
+
     /**
      * @param class-string $event
      */
@@ -177,10 +182,5 @@ class FakeEventDispatcher implements EventDispatcherInterface
         }
 
         return false;
-    }
-
-    public function clear(): void
-    {
-        $this->dispatchedEvents = [];
     }
 }

--- a/src/Traits/InteractsWithEvents.php
+++ b/src/Traits/InteractsWithEvents.php
@@ -9,14 +9,26 @@ use Spiral\Testing\Events\FakeEventDispatcher;
 
 trait InteractsWithEvents
 {
-    public function fakeEventDispatcher(array $eventsToFake = []): FakeEventDispatcher
+    /**
+     * @param bool $decorate If false then original eventDispatcher will be fully replace by Fake, otherwise it will be decorated.
+     */
+    public function fakeEventDispatcher(array $eventsToFake = [], bool $decorate = false): FakeEventDispatcher
     {
-        $this->getContainer()->removeBinding(EventDispatcherInterface::class);
+        $eventDispatcher = null;
+        if ($decorate) {
+            $eventDispatcher = $this->getContainer()->get(EventDispatcherInterface::class);
+        } else {
+            $this->getContainer()->removeBinding(EventDispatcherInterface::class);
+        }
+
         $this->getContainer()->bindSingleton(
             EventDispatcherInterface::class,
             $dispatcher = $this->getContainer()->make(
                 FakeEventDispatcher::class,
-                ['eventsToFake' => $eventsToFake],
+                [
+                    'eventDispatcher' => $eventDispatcher,
+                    'eventsToFake' => $eventsToFake,
+                ],
             ),
         );
 

--- a/tests/src/Event/EventDispatcherTest.php
+++ b/tests/src/Event/EventDispatcherTest.php
@@ -127,6 +127,19 @@ final class EventDispatcherTest extends TestCase
         self::assertInstanceOf(AnotherEvent::class, $inner->traces[1]);
     }
 
+    public function testClear(): void
+    {
+        $eventDispatcher = $this->fakeEventDispatcher();
+        $eventDispatcher->dispatch(new SomeEvent(2025));
+        $eventDispatcher->dispatch(new AnotherEvent('boo'));
+        $eventDispatcher->assertDispatched(SomeEvent::class);
+        $eventDispatcher->assertDispatched(AnotherEvent::class);
+        $eventDispatcher->clear();
+
+        $eventDispatcher->assertNotDispatched(SomeEvent::class);
+        $eventDispatcher->assertNotDispatched(AnotherEvent::class);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/src/Event/EventDispatcherTest.php
+++ b/tests/src/Event/EventDispatcherTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Testing\Tests\Event;
 
 use PHPUnit\Framework\ExpectationFailedException;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Testing\Events\FakeEventDispatcher;
 use Spiral\Testing\Tests\App\Event\AnotherEvent;
 use Spiral\Testing\Tests\App\Event\SomeEvent;
@@ -101,6 +102,29 @@ final class EventDispatcherTest extends TestCase
         $this->expectExceptionMessage('Event [Spiral\Testing\Tests\App\Event\SomeEvent] does not have the [Spiral\Testing\Tests\App\Listener\AnotherListener] listener attached to it.');
 
         $this->eventDispatcher->assertListening(SomeEvent::class, AnotherListener::class);
+    }
+
+    public function testDecorate(): void
+    {
+        $inner = new class() implements EventDispatcherInterface {
+            public array $traces = [];
+
+            public function dispatch(object $event)
+            {
+                $this->traces[] = $event;
+            }
+        };
+        $this->getContainer()->bindSingleton(EventDispatcherInterface::class, $inner);
+
+        $eventDispatcher = $this->fakeEventDispatcher(decorate: true);
+        $eventDispatcher->dispatch(new SomeEvent(2025));
+        $eventDispatcher->dispatch(new AnotherEvent('boo'));
+        $eventDispatcher->assertDispatched(SomeEvent::class);
+        $eventDispatcher->assertDispatched(AnotherEvent::class);
+
+        self::assertCount(2, $inner->traces);
+        self::assertInstanceOf(SomeEvent::class, $inner->traces[0]);
+        self::assertInstanceOf(AnotherEvent::class, $inner->traces[1]);
     }
 
     protected function setUp(): void

--- a/tests/src/Event/EventDispatcherTest.php
+++ b/tests/src/Event/EventDispatcherTest.php
@@ -106,7 +106,7 @@ final class EventDispatcherTest extends TestCase
 
     public function testDecorate(): void
     {
-        $inner = new class() implements EventDispatcherInterface {
+        $inner = new class implements EventDispatcherInterface {
             public array $traces = [];
 
             public function dispatch(object $event)


### PR DESCRIPTION
I need something like https://symfony.com/doc/current/components/event_dispatcher/traceable_dispatcher.html

FakeEventDispatcher can satisfy my needs

Now we can manage `evict or decorate` for original EventDispatcher.
```php
$eventDispatcher = $this->fakeEventDispatcher(decorate: true);
```
