### PR TITLE
Fix/call finalizers in fakehttp

### DIFF
--- a/src/Http/FakeHttp.php
+++ b/src/Http/FakeHttp.php
@@ -17,6 +17,7 @@ use Spiral\Auth\ActorProviderInterface;
 use Spiral\Auth\TokenStorageInterface;
 use Spiral\Auth\Transport\HeaderTransport;
 use Spiral\Auth\TransportRegistry;
+use Spiral\Boot\FinalizerInterface;
 use Spiral\Core\Attribute\Proxy;
 use Spiral\Core\FactoryInterface;
 use Spiral\Http\Http;
@@ -443,7 +444,13 @@ class FakeHttp
                 ->handle($request);
         };
 
-        return new TestResponse(($this->scope)($handler, $bindings));
+        try {
+            return new TestResponse(($this->scope)($handler, $bindings));
+        } finally {
+            if ($this->container->has(FinalizerInterface::class)) {
+                $this->container->get(FinalizerInterface::class)->finalize(false);
+            }
+        }
     }
 
     protected function validateRequestData($data): void

--- a/tests/src/Http/FakeHttpTest.php
+++ b/tests/src/Http/FakeHttpTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Spiral\Testing\Tests\Http;
 
 use PHPUnit\Framework\ExpectationFailedException;
+use Spiral\Boot\FinalizerInterface;
 use Spiral\Core\Internal\Introspector;
 use Spiral\Testing\Attribute\TestScope;
 use Spiral\Testing\Tests\App\Middleware\FailMiddleware;
+use Spiral\Testing\Tests\Http\Stub\FakeFinalizer;
 use Spiral\Testing\Tests\Http\Stub\StaticResultMiddleware;
 use Spiral\Testing\Tests\TestCase;
 
@@ -153,5 +155,33 @@ final class FakeHttpTest extends TestCase
         $response = $this->fakeHttp()->get('/get/query-params', ['foo' => 'bar', 'baz' => ['foo1' => 'bar1']]);
         $response->assertBodySame('{"foo":"bar","baz":{"foo1":"bar1"}}');
         $this->assertSame(['bar', 'foo', 'root'], Introspector::scopeNames($this->getContainer()));
+    }
+
+    public function testFinalizersAreCalledAfterRequest(): void
+    {
+        $finalizer = new FakeFinalizer();
+        $this->getContainer()->bindSingleton(FinalizerInterface::class, $finalizer);
+
+        $this->assertCount(0, $finalizer->calls);
+
+        $this->fakeHttp()->get('/get/query-params');
+
+        $this->assertCount(1, $finalizer->calls);
+        $this->assertFalse($finalizer->calls[0]['terminate']);
+    }
+
+    public function testFinalizersAreCalledAfterEachRequest(): void
+    {
+        $finalizer = new FakeFinalizer();
+        $this->getContainer()->bindSingleton(FinalizerInterface::class, $finalizer);
+
+        $this->fakeHttp()->get('/get/query-params');
+        $this->fakeHttp()->post('/post/json', ['foo' => 'bar']);
+        $this->fakeHttp()->get('/get/headers');
+
+        $this->assertCount(3, $finalizer->calls);
+        foreach ($finalizer->calls as $call) {
+            $this->assertFalse($call['terminate']);
+        }
     }
 }

--- a/tests/src/Http/Stub/FakeFinalizer.php
+++ b/tests/src/Http/Stub/FakeFinalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Testing\Tests\Http\Stub;
+
+use Spiral\Boot\FinalizerInterface;
+
+final class FakeFinalizer implements FinalizerInterface
+{
+    /** @var array<array{terminate: bool}> */
+    public array $calls = [];
+
+    public function addFinalizer(callable $finalizer): static
+    {
+        return $this;
+    }
+
+    public function finalize(bool $terminate = false): void
+    {
+        $this->calls[] = ['terminate' => $terminate];
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

FakeHttp::handleRequest() now calls FinalizerInterface::finalize(false) after each request, matching the behavior of RoadRunner HTTP Dispatcher.                                                              

## Why?

Without calling finalizers, state leaks between sequential HTTP requests in tests. For example, Cycle ORM 
heap is not cleaned between requests (cleanup is registered in CycleOrmBootloader), causing entities cached 
in memory to mask persistence bugs.

## Checklist

- Closes #86
- Tested
    - [x] Tested manually
    - [x] Unit tests 

