### PR TITLE
Update PHPunit to 13.0.5

### DIFF
--- a/.github/workflows/cs-fix.yml
+++ b/.github/workflows/cs-fix.yml
@@ -12,5 +12,6 @@ jobs:
     permissions:
       contents: write
     uses: spiral/gh-actions/.github/workflows/cs-fix.yml@master
-
-...
+    with:
+      php: >-
+        ['8.4']

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,3 +14,5 @@ jobs:
                 ['ubuntu-latest']
             stability: >-
                 ['prefer-lowest', 'prefer-stable']
+            php: >-
+                ['8.4']

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,4 +15,4 @@ jobs:
             stability: >-
                 ['prefer-lowest', 'prefer-stable']
             php: >-
-                ['8.4']
+                ['8.4', '8.5']

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -13,3 +13,5 @@ jobs:
         with:
             os: >-
                 ['ubuntu-latest']
+            php: >-
+                ['8.4']

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /vendor/
 /.env
 /composer.lock
+/.phpunit.result.cache
 *.log
 *.exe

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     ],
     "require": {
         "ext-json": "*",
-        "php": ">=8.1",
+        "php": ">=8.4",
         "nyholm/psr7": "^1.8.2",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.0.5",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "php": ">=8.1",
         "nyholm/psr7": "^1.8.2",
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^9.6 || 10.5.45",
+        "phpunit/phpunit": "^13.0.5",
         "spiral/auth": "^3.16",
         "spiral/auth-http": "^3.16",
         "spiral/boot": "^3.16",
@@ -64,9 +64,6 @@
         "spiral/translator": "^3.16",
         "spiral/scaffolder": "^3.16",
         "symfony/mime": "^6.4.18 || ^7.2 || ^8.0"
-    },
-    "conflict": {
-        "phpunit/phpunit": ">10.5.45"
     },
     "suggest": {
         "brianium/paratest": "Required to run tests in parallel (^6.0).",
@@ -95,6 +92,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
+        "lock": false,
         "sort-packages": true,
         "allow-plugins": {
             "spiral/composer-publish-plugin": false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,43 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         cacheResultFile="runtime/phpunit/result.cache"
-         bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         executionOrder="random"
-         failOnWarning="true"
-         failOnRisky="true"
-         failOnEmptyTestSuite="true"
-         beStrictAboutOutputDuringTests="true"
-         backupStaticProperties="false"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="runtime/coverage"/>
-            <text outputFile="runtime/coverage.txt"/>
-            <clover outputFile="runtime/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="runtime/report.junit.xml"/>
-    </logging>
-    <source>
-        <include>
-            <directory>src</directory>
-        </include>
-        <exclude>
-            <directory>tests</directory>
-        </exclude>
-    </source>
-    <php>
-        <env name="DEBUG" value="true"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <report>
+      <html outputDirectory="runtime/coverage"/>
+      <text outputFile="runtime/coverage.txt"/>
+      <clover outputFile="runtime/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <logging>
+    <junit outputFile="runtime/report.junit.xml"/>
+  </logging>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+    <exclude>
+      <directory>tests</directory>
+    </exclude>
+  </source>
+  <php>
+    <env name="DEBUG" value="true"/>
+  </php>
 </phpunit>

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -228,16 +228,16 @@ abstract class TestCase extends BaseTestCase
         $this->runTraitSetUpOrTearDown('tearDown');
     }
 
-    protected function runTest(): mixed
+    protected function invokeTestMethod(string $methodName, array $testArguments): mixed
     {
         $scope = $this->getTestScope();
         if ($scope === null) {
-            return parent::runTest();
+            return parent::invokeTestMethod($methodName, $testArguments);
         }
 
         $scopes = \is_array($scope->scope) ? $scope->scope : [$scope->scope];
-        $result = self::runScopes($scopes, function (): mixed {
-            return parent::runTest();
+        $result = self::runScopes($scopes, function () use ($methodName, $testArguments): mixed {
+            return parent::invokeTestMethod($methodName, $testArguments);
         }, $this->getContainer(), $scope->bindings);
 
         return $result;

--- a/tests/src/Traits/InteractsWithDispatcherTest.php
+++ b/tests/src/Traits/InteractsWithDispatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Testing\Tests\Traits;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Spiral\Boot\DispatcherInterface;
 use Spiral\Boot\Environment;
 use Spiral\Boot\EnvironmentInterface;
@@ -69,6 +70,7 @@ final class InteractsWithDispatcherTest extends TestCase
         $this->assertDispatcherCannotBeServed($dispatcher::class);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testGetRegisteredDispatchers(): void
     {
         $dispatcherA = $this->createMock(DispatcherInterface::class);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Updated PHPUnit to 13.0.5
- Changed base TestCase to extend new `PHPUnit\Framework\TestCase::invokeTestMethod` instead of `PHPUnit\Framework\TestCase::runTest`
- Updated PHPUnit configuration to match current schema
- Ignore the PHPUnit result cache in git
- Tell composer to not generate a lock file

## Why?

Many current versions of great testing tools/libraries (such as Pest) will not work with the current spiral/testing package due to it being pinned to an old version of PHPUnit.

## Checklist

- Closes #81
- Tested
    - [x] Tested manually
    - [ ] Unit tests added